### PR TITLE
Ensure resource pack is 1.21 compatible

### DIFF
--- a/src/main/resources/resourcepacks/snowy_grass_plus/pack.mcmeta
+++ b/src/main/resources/resourcepacks/snowy_grass_plus/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 15,
+    "pack_format": 34,
     "description": "Improved Texture for the Top of Snowy Grass"
   }
 }


### PR DESCRIPTION
`15` is a reference to 23w17a *(1.20)* which is not supported by 1.21/1.21.1, therefore it must be `34` to be marked as compatible.